### PR TITLE
修复了文本摘要的两个小问题，并新增了测试用例

### DIFF
--- a/jiagu/textrank.py
+++ b/jiagu/textrank.py
@@ -90,8 +90,9 @@ class Summarize(object):
         if stop_words_file:
             self.__stop_words_file = stop_words_file
         if use_stopword:
-            for word in open(self.__stop_words_file, 'r', encoding='utf-8'):
-                self.__stop_words.add(word.strip())
+            with open(self.__stop_words_file, 'r', encoding='utf-8') as f:
+                for word in f:
+                    self.__stop_words.add(word.strip())
 
     def filter_dictword(self, sents):
         _sents = []

--- a/jiagu/utils.py
+++ b/jiagu/utils.py
@@ -37,7 +37,8 @@ def cut_sentences(sentence):
         if ch in sentence_delimiters:
             yield ''.join(tmp)
             tmp = []
-    yield ''.join(tmp)
+    if len(tmp) > 0:    # 如以定界符结尾的文本的文本信息会在循环中返回，无需再次传递
+        yield ''.join(tmp)
 
 
 def cut_filter_words(cutted_sentences, stopwords, use_stopwords=False):

--- a/test/test_textrank.py
+++ b/test/test_textrank.py
@@ -121,7 +121,29 @@ class TestTextRank(unittest.TestCase):
         print(summarize)
         self.assertTrue(len(summarize) == 3)
 
+    def test_cut_sentences(self):
+        text = '''江西省上饶市信州区人民法院 刑事判决书 （2016）赣1102刑初274号 公诉机关
+                上饶市信州区人民检察院。 被告人曾榴仙，女，1954年11月22日出生于江西省上饶市信州区，
+                汉族，文盲，无业，家住上饶市信州区，因涉嫌过失致人死亡罪，2016年4月27日被上饶市公
+                安局信州区分局刑事拘留，2016年6月1日被执行逮捕。辩护人毛巧云，江西盛义律师事务所
+                律师。 上饶市信州区人民检察院以饶信检公诉刑诉［2016］260号起诉书指控被告人曾榴仙犯
+                过失致人死亡罪，于2016年8月22日向本院提起公诉。'''
+        text = re.sub('\\n| ', '', text)
+        sentences = list(utils.cut_sentences(text))
+        self.assertEqual(len(sentences), 4)
+
+    def test_short_text_summarize(self):
+        text = '''江西省上饶市信州区人民法院 刑事判决书 （2016）赣1102刑初274号 公诉机关
+        上饶市信州区人民检察院。 被告人曾榴仙，女，1954年11月22日出生于江西省上饶市信州区，
+        汉族，文盲，无业，家住上饶市信州区，因涉嫌过失致人死亡罪，2016年4月27日被上饶市公
+        安局信州区分局刑事拘留，2016年6月1日被执行逮捕。辩护人毛巧云，江西盛义律师事务所
+        律师。 上饶市信州区人民检察院以饶信检公诉刑诉［2016］260号起诉书指控被告人曾榴仙犯
+        过失致人死亡罪，于2016年8月22日向本院提起公诉。'''
+        text = re.sub('\\n| ', '', text)
+        summarize = jiagu.summarize(text, 5)  # 设定摘要句子数大于文本句子数
+        print(summarize)
+        print(len(summarize))
+
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
本次pr修复了以下两个问题：
1. textrank.py在往停用词集合添加词时，读取的文本io未关闭；
2. utils.cut_sentences如在文本以定界符结尾时，最后会额外返回一个空字符串；
并新增了以下两个测试用例：
1. cut_sentences，测试是否会额外返回空字符串；
2. 当文本句子数小于设定的topsen时，测试代码是否能正常运行。